### PR TITLE
Scipy pin travis

### DIFF
--- a/.conda_ci_before_install.sh
+++ b/.conda_ci_before_install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b
+export PATH=/home/travis/miniconda3/bin:$PATH
+conda update --yes conda

--- a/.conda_ci_before_install.sh
+++ b/.conda_ci_before_install.sh
@@ -5,5 +5,4 @@ set -e -x
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b
-export PATH=/home/travis/miniconda3/bin:$PATH
 conda update --yes conda

--- a/.conda_ci_install.sh
+++ b/.conda_ci_install.sh
@@ -3,5 +3,5 @@
 set -e -x
 
 conda install --yes nomkl
-conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
+conda install --yes python=$TRAVIS_PYTHON_VERSION "scipy==1.2rc2" matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
 conda install --yes -c conda-forge pandoc

--- a/.conda_ci_install.sh
+++ b/.conda_ci_install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+conda install --yes nomkl
+conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
+conda install --yes -c conda-forge pandoc

--- a/.conda_ci_install.sh
+++ b/.conda_ci_install.sh
@@ -3,5 +3,6 @@
 set -e -x
 
 conda install --yes nomkl
-conda install --yes python=$TRAVIS_PYTHON_VERSION "scipy==1.2rc2" matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
+conda install --yes python=$TRAVIS_PYTHON_VERSION matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
 conda install --yes -c conda-forge pandoc
+pip install "scipy==1.2rc2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
     then
         bash .conda_ci_install.sh;
     else
-        pip install .[test];
+        pip install .[test] && pip install "scipy==1.2rc2";
     fi
 
 # Run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
     then
       source .conda_ci_before_install.sh;
      else
-       pip install --upgrade pip && pip install python-coveralls;
+       pip install --upgrade pip;
      fi
 
 install:
@@ -45,4 +45,5 @@ script:
 
 # Calculate coverage
 after_success:
+   - pip install python-coveralls
    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,16 @@ matrix:
 before_install:
   - if [[ $PYTHON_FLAVOR == "conda" ]];
     then
-      source .conda_ci_before_install.sh;
+        export PATH=/home/travis/miniconda3/bin:$PATH &&
+        bash .conda_ci_before_install.sh;
      else
-       pip install --upgrade pip;
+        pip install --upgrade pip;
      fi
 
 install:
   - if [[ $PYTHON_FLAVOR == "conda" ]];
     then
-        source .conda_ci_install.sh;
+        bash .conda_ci_install.sh;
     else
         pip install .[test];
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,48 @@
 language: python
 
+python:
+  - "3.5"
+  - "3.6"
+env:
+  - PYTHON_FLAVOR=standard
+  - PYTHON_FLAVOR=conda
+
 matrix:
   include:
-    - python: "3.5"
-    - python: "3.6"
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+      env:
+        - PYTHON_FLAVOR=standard
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+      env:
+        - PYTHON_FLAVOR=conda
+
+before_install:
+  - if [[ $PYTHON_FLAVOR == "conda" ]];
+    then
+      source .conda_ci_before_install.sh;
+     else
+       pip install --upgrade pip && pip install python-coveralls;
+     fi
+
+install:
+  - if [[ $PYTHON_FLAVOR == "conda" ]];
+    then
+        source .conda_ci_install.sh;
+    else
+        pip install .[test];
+    fi
 
 notifications:
   email: false
 
-# Setup anaconda
-before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda3/bin:$PATH
-  - conda update --yes conda
-install:
-  - conda install --yes nomkl
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
-  - conda install --yes -c conda-forge pandoc
-  - python -c "import matplotlib"
-  - pip install python-coveralls #nose-cov
-  - python setup.py install
-
-
-# Recipe from http://dan-blanchard.roughdraft.io/7045057-quicker-travis-builds-that-rely-on-numpy-and-scipy-using-miniconda
 # Run test
 script:
   - nosetests --with-coverage --cover-package=pweave
-#  - nosetests --with-cov --cov Pweave --cov-config .coveragerc --logging-level=INFO
 
 # Calculate coverage
 after_success:
    - coveralls
-#  - coveralls --config_file .coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ install:
         pip install .[test];
     fi
 
-notifications:
-  email: false
-
 # Run test
 script:
   - nosetests --with-coverage --cover-package=pweave


### PR DESCRIPTION
 This PR depends on #2 and fixes the tests by installing a release candidate version of scipy that will not cause numpy to warn about an upcoming deprecation. This warning is bleeding into some pweaved output and causing failing tests.