### PR TITLE
black code format linting

### DIFF
--- a/.conda_ci_install.sh
+++ b/.conda_ci_install.sh
@@ -5,4 +5,4 @@ set -e -x
 conda install --yes nomkl
 conda install --yes python=$TRAVIS_PYTHON_VERSION matplotlib markdown pygments coverage ipython nose nbformat jupyter_client nbconvert notebook
 conda install --yes -c conda-forge pandoc
-pip install "scipy==1.2rc2"
+pip install "scipy==1.2rc2" black

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "3.6"
-  - "3.7"
 env:
   - PYTHON_FLAVOR=standard
   - PYTHON_FLAVOR=conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
+  - "3.7"
 env:
   - PYTHON_FLAVOR=standard
   - PYTHON_FLAVOR=conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
 # Run test
 script:
   - nosetests --with-coverage --cover-package=pweave
+  - black --check .
 
 # Calculate coverage
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "ipykernel",
     ],
     extras_require={
-        "test": ["scipy", "matplotlib", "coverage", "ipython", "nose", "notebook"],
+        "test": ["scipy", "matplotlib", "coverage", "nose", "notebook", "black"],
         "doc": ["sphinx", "sphinx_rtd_theme"],
     },
     license="LICENSE.txt",


### PR DESCRIPTION
This adds a check to make sure that all relevant code is formatting according to the black style.

The PR also drops testing of the package with python 3.5, since the earliest version of python that black supports is py3.6. 